### PR TITLE
Removing depreciated configs

### DIFF
--- a/docker/airflow.cfg
+++ b/docker/airflow.cfg
@@ -3,62 +3,11 @@
 # subfolder in a code repository. This path must be absolute.
 dags_folder = /opt/airflow/dags
 
-# The folder where airflow should store its log files
-# This path must be absolute
-base_log_folder = /opt/airflow/logs
-
-# Airflow can store logs remotely in AWS S3, Google Cloud Storage or Elastic Search.
-# Set this to True if you want to enable remote logging.
-remote_logging = False
-
 # Users must supply an Airflow connection id that provides access to the storage
 # location.
 remote_log_conn_id =
 remote_base_log_folder =
 encrypt_s3_logs = False
-
-# Logging level
-logging_level = INFO
-
-# Logging level for Flask-appbuilder UI
-fab_logging_level = WARN
-
-# Logging class
-# Specify the class that will specify the logging configuration
-# This class has to be on the python classpath
-# Example: logging_config_class = my.path.default_local_settings.LOGGING_CONFIG
-logging_config_class =
-
-# Flag to enable/disable Colored logs in Console
-# Colour the logs when the controlling terminal is a TTY.
-colored_console_log = True
-
-# Log format for when Colored logs is enabled
-colored_log_format = [%%(blue)s%%(asctime)s%%(reset)s] {{%%(blue)s%%(filename)s:%%(reset)s%%(lineno)d}} %%(log_color)s%%(levelname)s%%(reset)s - %%(log_color)s%%(message)s%%(reset)s
-colored_formatter_class = airflow.utils.log.colored_log.CustomTTYColoredFormatter
-
-# Format of Log line
-log_format = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
-simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
-
-# Log filename format
-log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log
-log_processor_filename_template = {{ filename }}.log
-dag_processor_manager_log_location = /opt/airflow/logs/dag_processor_manager/dag_processor_manager.log
-
-# Name of handler to read task instance logs.
-# Default to use task handler.
-task_log_reader = task
-
-# Hostname by providing a path to a callable, which will resolve the hostname.
-# The format is "package:function".
-#
-# For example, default value "socket:getfqdn" means that result from getfqdn() of "socket"
-# package will be used as hostname.
-#
-# No argument should be required in the function specified.
-# If using IP address as hostname is preferred, use value ``airflow.utils.net:get_host_ip_address``
-hostname_callable = socket:getfqdn
 
 # Default timezone in case supplied date times are naive
 # can be utc (default), system, or any IANA timezone string (e.g. Europe/Amsterdam)
@@ -74,50 +23,10 @@ executor = SequentialExecutor
 # sql_alchemy_conn = sqlite:////tmp/airflow.db
 # sql_alchemy_conn=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
 
-# The encoding for the databases
-sql_engine_encoding = utf-8
-
-# If SqlAlchemy should pool database connections.
-sql_alchemy_pool_enabled = True
-
-# The SqlAlchemy pool size is the maximum number of database connections
-# in the pool. 0 indicates no limit.
-sql_alchemy_pool_size = 5
-
-# The maximum overflow size of the pool.
-# When the number of checked-out connections reaches the size set in pool_size,
-# additional connections will be returned up to this limit.
-# When those additional connections are returned to the pool, they are disconnected and discarded.
-# It follows then that the total number of simultaneous connections the pool will allow
-# is pool_size + max_overflow,
-# and the total number of "sleeping" connections the pool will allow is pool_size.
-# max_overflow can be set to -1 to indicate no overflow limit;
-# no limit will be placed on the total number of concurrent connections. Defaults to 10.
-sql_alchemy_max_overflow = 10
-
-# The SqlAlchemy pool recycle is the number of seconds a connection
-# can be idle in the pool before it is invalidated. This config does
-# not apply to sqlite. If the number of DB connections is ever exceeded,
-# a lower config value will allow the system to recover faster.
-sql_alchemy_pool_recycle = 1800
-
-# Check connection at the start of each connection pool checkout.
-# Typically, this is a simple statement like "SELECT 1".
-# More information here:
-# https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic
-sql_alchemy_pool_pre_ping = True
-
-# The schema to use for the metadata database.
-# SqlAlchemy supports databases with the concept of multiple schemas.
-sql_alchemy_schema =
-
 # The amount of parallelism as a setting to the executor. This defines
 # the max number of task instances that should run simultaneously
 # on this airflow installation
 parallelism = 32
-
-# The number of task instances allowed to run concurrently by the scheduler
-dag_concurrency = 16
 
 # Are DAGs paused by default at creation
 dags_are_paused_at_creation = True
@@ -212,9 +121,6 @@ endpoint_url = http://localhost:8080
 # failed task. Helpful for debugging purposes.
 fail_fast = False
 
-[api]
-# How to authenticate users of the API
-auth_backend = airflow.api.auth.backend.default
 
 [lineage]
 # what lineage backend to use
@@ -276,7 +182,7 @@ worker_refresh_interval = 30
 
 # Secret key used to run your flask app
 # It should be as random as possible
-secret_key = temporary_key
+secret_key = temporary_key #this sould be a random_key
 
 # Number of workers to run the Gunicorn web server
 workers = 4
@@ -314,10 +220,6 @@ filter_by_owner = False
 # in order to user the ldapgroup mode.
 owner_mode = user
 
-# Default DAG view. Valid values are:
-# tree, graph, duration, gantt, landing_times
-dag_default_view = tree
-
 # "Default DAG orientation. Valid values are:"
 # LR (Left->Right), TB (Top->Bottom), RL (Right->Left), BT (Bottom->Top)
 dag_orientation = LR
@@ -349,9 +251,6 @@ page_size = 100
 # Use FAB-based webserver with RBAC feature
 rbac = False
 
-# Define the color of navigation bar
-navbar_color = #007A87
-
 # Default dagrun to show in UI
 default_dag_run_display_number = 25
 
@@ -377,9 +276,6 @@ proxy_fix_x_prefix = 1
 # Set secure flag on session cookie
 cookie_secure = False
 
-# Set samesite policy on session cookie
-cookie_samesite =
-
 # Default setting for wrap toggle on DAG code and TI log views.
 default_wrap = False
 
@@ -396,13 +292,6 @@ x_frame_enabled = True
 # Update FAB permissions and sync security manager roles
 # on webserver startup
 update_fab_perms = True
-
-# Minutes of non-activity before logged out from UI
-# 0 means never get forcibly logged out
-force_log_out_after = 0
-
-# The UI cookie lifetime in days
-session_lifetime_days = 30
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp
@@ -486,9 +375,6 @@ flower_port = 5555
 # Example: flower_basic_auth = user1:password1,user2:password2
 flower_basic_auth =
 
-# Default queue that tasks get assigned to and that worker listen on.
-default_queue = default
-
 # How many processes CeleryExecutor uses to sync task state.
 # 0 means to use max(1, number of cores - 1) processes.
 sync_parallelism = 0
@@ -559,9 +445,6 @@ run_duration = -1
 # -1 indicates unlimited number
 num_runs = -1
 
-# The number of seconds to wait between consecutive DAG file processing
-processor_poll_interval = 1
-
 # after how much time (seconds) a new DAGs should be picked up from the filesystem
 min_file_process_interval = 0
 
@@ -601,7 +484,6 @@ catchup_by_default = True
 max_tis_per_query = 512
 
 # Statsd (https://github.com/etsy/statsd) integration settings
-statsd_on = False
 statsd_host = localhost
 statsd_port = 8125
 statsd_prefix = airflow
@@ -700,10 +582,6 @@ keytab = airflow.keytab
 [github_enterprise]
 api_rev = v3
 
-[admin]
-# UI to hide sensitive variable fields when set to True
-hide_sensitive_variable_fields = True
-
 [elasticsearch]
 # Elasticsearch host
 host =
@@ -736,7 +614,6 @@ verify_certs = True
 # The repository, tag and imagePullPolicy of the Kubernetes Image for the Worker to Run
 worker_container_repository =
 worker_container_tag =
-worker_container_image_pull_policy = IfNotPresent
 
 # If True (default), worker pods will be deleted upon termination
 delete_worker_pods = True
@@ -746,161 +623,6 @@ worker_pods_creation_batch_size = 1
 
 # The Kubernetes namespace where airflow workers should be created. Defaults to ``default``
 namespace = default
-
-# The name of the Kubernetes ConfigMap containing the Airflow Configuration (this file)
-# Example: airflow_configmap = airflow-configmap
-airflow_configmap =
-
-# The name of the Kubernetes ConfigMap containing ``airflow_local_settings.py`` file.
-#
-# For example:
-#
-# ``airflow_local_settings_configmap = "airflow-configmap"`` if you have the following ConfigMap.
-#
-# ``airflow-configmap.yaml``:
-#
-# .. code-block:: yaml
-#
-#   ---
-#   apiVersion: v1
-#   kind: ConfigMap
-#   metadata:
-#     name: airflow-configmap
-#   data:
-#     airflow_local_settings.py: |
-#         def pod_mutation_hook(pod):
-#             ...
-#     airflow.cfg: |
-#         ...
-# Example: airflow_local_settings_configmap = airflow-configmap
-airflow_local_settings_configmap =
-
-# For docker image already contains DAGs, this is set to ``True``, and the worker will
-# search for dags in dags_folder,
-# otherwise use git sync or dags volume claim to mount DAGs
-dags_in_image = False
-
-# For either git sync or volume mounted DAGs, the worker will look in this subpath for DAGs
-dags_volume_subpath = /opt/airflow/dags
-
-# For DAGs mounted via a volume claim (mutually exclusive with git-sync and host path)
-dags_volume_claim = /opt/airflow/dags
-
-# For volume mounted logs, the worker will look in this subpath for logs
-logs_volume_subpath = /opt/airflow/dags
-
-# A shared volume claim for the logs
-logs_volume_claim = /opt/airflow/dags
-# For DAGs mounted via a hostPath volume (mutually exclusive with volume claim and git-sync)
-# Useful in local environment, discouraged in production
-dags_volume_host = /opt/airflow/dags
-
-# A hostPath volume for the logs
-# Useful in local environment, discouraged in production
-logs_volume_host = /opt/airflow/dags
-
-# A list of configMapsRefs to envFrom. If more than one configMap is
-# specified, provide a comma separated list: configmap_a,configmap_b
-env_from_configmap_ref =
-
-# A list of secretRefs to envFrom. If more than one secret is
-# specified, provide a comma separated list: secret_a,secret_b
-env_from_secret_ref =
-
-# Git credentials and repository for DAGs mounted via Git (mutually exclusive with volume claim)
-git_repo =
-git_branch =
-git_subpath =
-
-# The specific rev or hash the git_sync init container will checkout
-# This becomes GIT_SYNC_REV environment variable in the git_sync init container for worker pods
-git_sync_rev =
-
-# Use git_user and git_password for user authentication or git_ssh_key_secret_name
-# and git_ssh_key_secret_key for SSH authentication
-git_user =
-git_password =
-git_sync_root = /git
-git_sync_dest = repo
-
-# Mount point of the volume if git-sync is being used.
-# i.e. /opt/airflow/dags
-git_dags_folder_mount_point =
-
-# To get Git-sync SSH authentication set up follow this format
-#
-# ``airflow-secrets.yaml``:
-#
-# .. code-block:: yaml
-#
-#   ---
-#   apiVersion: v1
-#   kind: Secret
-#   metadata:
-#     name: airflow-secrets
-#   data:
-#     # key needs to be gitSshKey
-#     gitSshKey: <base64_encoded_data>
-# Example: git_ssh_key_secret_name = airflow-secrets
-git_ssh_key_secret_name =
-
-# To get Git-sync SSH authentication set up follow this format
-#
-# ``airflow-configmap.yaml``:
-#
-# .. code-block:: yaml
-#
-#   ---
-#   apiVersion: v1
-#   kind: ConfigMap
-#   metadata:
-#     name: airflow-configmap
-#   data:
-#     known_hosts: |
-#         github.com ssh-rsa <...>
-#     airflow.cfg: |
-#         ...
-# Example: git_ssh_known_hosts_configmap_name = airflow-configmap
-git_ssh_known_hosts_configmap_name =
-
-# To give the git_sync init container credentials via a secret, create a secret
-# with two fields: GIT_SYNC_USERNAME and GIT_SYNC_PASSWORD (example below) and
-# add ``git_sync_credentials_secret = <secret_name>`` to your airflow config under the
-# ``kubernetes`` section
-#
-# Secret Example:
-#
-# .. code-block:: yaml
-#
-#   ---
-#   apiVersion: v1
-#   kind: Secret
-#   metadata:
-#     name: git-credentials
-#   data:
-#     GIT_SYNC_USERNAME: <base64_encoded_git_username>
-#     GIT_SYNC_PASSWORD: <base64_encoded_git_password>
-git_sync_credentials_secret =
-
-# For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
-git_sync_container_repository = k8s.gcr.io/git-sync
-git_sync_container_tag = v3.1.1
-git_sync_init_container_name = git-sync-clone
-git_sync_run_as_user = 65533
-
-# The name of the Kubernetes service account to be associated with airflow workers, if any.
-# Service accounts are required for workers that require access to secrets or cluster resources.
-# See the Kubernetes RBAC documentation for more:
-# https://kubernetes.io/docs/admin/authorization/rbac/
-worker_service_account_name =
-
-# Any image pull secrets to be given to worker pods, If more than one secret is
-# required, provide a comma separated list: secret_a,secret_b
-image_pull_secrets =
-
-# GCP Service Account Keys to be provided to tasks run on Kubernetes Executors
-# Should be supplied in the format: key-name-1:key-path-1,key-name-2:key-path-2
-gcp_service_account_keys =
 
 # Use the service account kubernetes gives to pods to connect to kubernetes cluster.
 # It's intended for clients that expect to be running inside a pod running on kubernetes.
@@ -912,15 +634,6 @@ in_cluster = True
 # cluster_context =
 # config_file =
 
-# Affinity configuration as a single line formatted JSON object.
-# See the affinity model for top-level key names (e.g. ``nodeAffinity``, etc.):
-# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#affinity-v1-core
-affinity =
-
-# A list of toleration objects as a single line formatted JSON array
-# See:
-# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#toleration-v1-core
-tolerations =
 
 # Keyword parameters to pass while calling a kubernetes client core_v1_api methods
 # from Kubernetes Executor provided as a single line formatted JSON dictionary string.
@@ -932,59 +645,3 @@ tolerations =
 # for kubernetes api responses, which will cause the scheduler to hang.
 # The timeout is specified as [connect timeout, read timeout]
 kube_client_request_args = {{"_request_timeout" : [60,60] }}
-
-# Specifies the uid to run the first process of the worker pods containers as
-run_as_user =
-
-# Specifies a gid to associate with all containers in the worker pods
-# if using a git_ssh_key_secret_name use an fs_group
-# that allows for the key to be read, e.g. 65533
-fs_group =
-
-[kubernetes_node_selectors]
-
-# The Key-value pairs to be given to worker pods.
-# The worker pods will be scheduled to the nodes of the specified key-value pairs.
-# Should be supplied in the format: key = value
-
-[kubernetes_annotations]
-
-# The Key-value annotations pairs to be given to worker pods.
-# Should be supplied in the format: key = value
-
-[kubernetes_environment_variables]
-
-# The scheduler sets the following environment variables into your workers. You may define as
-# many environment variables as needed and the kubernetes launcher will set them in the launched workers.
-# Environment variables in this section are defined as follows
-# ``<environment_variable_key> = <environment_variable_value>``
-#
-# For example if you wanted to set an environment variable with value `prod` and key
-# ``ENVIRONMENT`` you would follow the following format:
-# ENVIRONMENT = prod
-#
-# Additionally you may override worker airflow settings with the ``AIRFLOW__<SECTION>__<KEY>``
-# formatting as supported by airflow normally.
-
-[kubernetes_secrets]
-
-# The scheduler mounts the following secrets into your workers as they are launched by the
-# scheduler. You may define as many secrets as needed and the kubernetes launcher will parse the
-# defined secrets and mount them as secret environment variables in the launched workers.
-# Secrets in this section are defined as follows
-# ``<environment_variable_mount> = <kubernetes_secret_object>=<kubernetes_secret_key>``
-#
-# For example if you wanted to mount a kubernetes secret key named ``postgres_password`` from the
-# kubernetes secret object ``airflow-secret`` as the environment variable ``POSTGRES_PASSWORD`` into
-# your workers you would follow the following format:
-# ``POSTGRES_PASSWORD = airflow-secret=postgres_credentials``
-#
-# Additionally you may override worker airflow settings with the ``AIRFLOW__<SECTION>__<KEY>``
-# formatting as supported by airflow normally.
-
-[kubernetes_labels]
-
-# The Key-value pairs to be given to worker pods.
-# The worker pods will be given these static labels, as well as some additional dynamic labels
-# to identify the task.
-# Should be supplied in the format: ``key = value``


### PR DESCRIPTION
It needs configuration in `secret_key`, replace with the output of `openssl rand -hex 30` to work.

The admin user has to be created by hand inside container to be accessible in UI with the command: 
```
airflow users create \
          --username name \
          --firstname fname \
          --lastname lname \
          --password pw \
          --role Admin \
          --email email@email.com
```
Maybe this can be done differently.